### PR TITLE
fix(apis/web): 修复 schema 配置问题

### DIFF
--- a/src/apiserver/pkg/apis/web/handler/system.go
+++ b/src/apiserver/pkg/apis/web/handler/system.go
@@ -363,8 +363,12 @@ func PluginsGet(c *gin.Context) {
 		if kind == constant.Metadata && len(plugin.MetadataExample) == 0 {
 			continue
 		}
-		// stream 类型的插件
+		// 当查询的插件类别为 stream 时，仅获取 StreamRoutePluginMap 匹配的插件
 		if kind == constant.Stream && schema.StreamRoutePluginMap[plugin.Name] == "" {
+			continue
+		}
+		// 只有 stream route 资源才能使用 stream 类型的插件，其他资源需要排除掉
+		if kind != constant.Stream && plugin.Type == constant.Stream {
 			continue
 		}
 		// 根据 apisixType 过滤

--- a/src/apiserver/pkg/utils/schema/3.2/schema.json
+++ b/src/apiserver/pkg/utils/schema/3.2/schema.json
@@ -7346,7 +7346,10 @@
               "apisix"
             ],
             "items": {
-              "pattern": "^(?!tag=)[ -~]*",
+              "pattern": "^[ -~]*$",
+              "not": {
+                "pattern": "^tag="
+              },
               "type": "string"
             },
             "minItems": 1,

--- a/src/apiserver/pkg/utils/schema/3.3/schema.json
+++ b/src/apiserver/pkg/utils/schema/3.3/schema.json
@@ -7346,7 +7346,10 @@
               "apisix"
             ],
             "items": {
-              "pattern": "^(?!tag=)[ -~]*",
+              "pattern": "^[ -~]*$",
+              "not": {
+                "pattern": "^tag="
+              },
               "type": "string"
             },
             "minItems": 1,


### PR DESCRIPTION
### Description

1. 插件列表接口过滤 stream 类型的插件，只能用于 stream route 资源
2. Go 的 regexp 包不支持 Perl 风格的正则语法，如：(?!...)，修改 loggly 插件的 pattern，用 not 关键字来替换 (?!...)

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)