### PR TITLE
fix(session): set explicit cookie path to prevent multiple session co…

### DIFF
--- a/src/apiserver/pkg/apis/web/router.go
+++ b/src/apiserver/pkg/apis/web/router.go
@@ -37,7 +37,10 @@ func RegisterWebApi(path string, router *gin.RouterGroup) {
 	group := router.Group(path)
 	// middleware: session
 	store := cookie.NewStore([]byte(config.G.Service.AppSecret))
-	store.Options(sessions.Options{MaxAge: int(config.G.Service.SessionCookieAge.Seconds())})
+	store.Options(sessions.Options{
+		Path:   "/",
+		MaxAge: int(config.G.Service.SessionCookieAge.Seconds()),
+	})
 	group.Use(sessions.Sessions(fmt.Sprintf("%s-session", config.G.Service.AppCode), store))
 
 	//  csrf


### PR DESCRIPTION
…okies

Previously, session cookies were created with empty Path field, causing browsers to default to request-specific paths. This resulted in 5 separate session cookies being created for different endpoints:
- /api/v1/web/accounts/userinfo
- /api/v1/web/gateways
- /api/v1/web/version-log
- /api/v1/web/enums
- /api/v1/web/env-vars

Now explicitly sets Path: "/" in session options to ensure a single shared cookie across all web API endpoints.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)