### PR TITLE
fix(sync): add resource type filter to GetSyncedItemByID queries

### DIFF
--- a/src/apiserver/pkg/biz/publish_test.go
+++ b/src/apiserver/pkg/biz/publish_test.go
@@ -119,7 +119,11 @@ func TestPublishRoutes(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.Route], 1)
 
 			// assert sync resource
-			syncedRoute, err := GetSyncedItemByID(tt.args.ctx, tt.args.route.ID)
+			syncedRoute, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.Route,
+				tt.args.route.ID,
+			)
 			assert.NoError(t, err)
 
 			assert.Equal(t, syncedRoute.ID, tt.args.route.ID)
@@ -181,7 +185,11 @@ func TestPublishService(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.Service], 1)
 
 			// assert sync resource
-			syncedResource, err := GetSyncedItemByID(tt.args.ctx, tt.args.service.ID)
+			syncedResource, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.Service,
+				tt.args.service.ID,
+			)
 			assert.NoError(t, err)
 
 			assert.Equal(t, syncedResource.ID, tt.args.service.ID)
@@ -243,7 +251,11 @@ func TestPublishUpstreams(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.Upstream], 1)
 
 			// assert sync resource
-			syncedResource, err := GetSyncedItemByID(tt.args.ctx, tt.args.upstream.ID)
+			syncedResource, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.Upstream,
+				tt.args.upstream.ID,
+			)
 			assert.NoError(t, err)
 
 			assert.Equal(t, syncedResource.ID, tt.args.upstream.ID)
@@ -305,7 +317,11 @@ func TestPublishConsumer(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.Consumer], 1)
 
 			// assert sync resource
-			syncedResource, err := GetSyncedItemByID(tt.args.ctx, tt.args.consumer.ID)
+			syncedResource, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.Consumer,
+				tt.args.consumer.ID,
+			)
 			assert.NoError(t, err)
 
 			assert.Equal(t, syncedResource.ID, tt.args.consumer.ID)
@@ -369,7 +385,11 @@ func TestPublishPluginConfigs(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.PluginConfig], 1)
 
 			// assert sync resource
-			syncedResource, err := GetSyncedItemByID(tt.args.ctx, tt.args.pluginConfig.ID)
+			syncedResource, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.PluginConfig,
+				tt.args.pluginConfig.ID,
+			)
 			assert.NoError(t, err)
 			assert.Equal(t, syncedResource.ID, tt.args.pluginConfig.ID)
 
@@ -432,7 +452,11 @@ func TestPublishGlobalRules(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.GlobalRule], 1)
 
 			// assert sync resource
-			syncedResource, err := GetSyncedItemByID(tt.args.ctx, tt.args.globalRule.ID)
+			syncedResource, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.GlobalRule,
+				tt.args.globalRule.ID,
+			)
 			assert.NoError(t, err)
 			assert.Equal(t, syncedResource.ID, tt.args.globalRule.ID)
 
@@ -490,7 +514,11 @@ func TestPublishProtos(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.Proto], 1)
 
 			// assert sync resource
-			syncedResource, err := GetSyncedItemByID(tt.args.ctx, tt.args.proto.ID)
+			syncedResource, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.Proto,
+				tt.args.proto.ID,
+			)
 			assert.NoError(t, err)
 			assert.Equal(t, syncedResource.ID, tt.args.proto.ID)
 
@@ -548,7 +576,11 @@ func TestPublishPluginMetadatas(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.PluginMetadata], 1)
 
 			// assert sync resource
-			syncedResource, err := GetSyncedItemByID(tt.args.ctx, tt.args.pluginMetadata.ID)
+			syncedResource, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.PluginMetadata,
+				tt.args.pluginMetadata.ID,
+			)
 			assert.NoError(t, err)
 			assert.Equal(t, syncedResource.ID, tt.args.pluginMetadata.ID)
 
@@ -614,7 +646,11 @@ func TestPublishConsumerGroups(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.ConsumerGroup], 1)
 
 			// assert sync resource
-			syncedResource, err := GetSyncedItemByID(tt.args.ctx, tt.args.consumerGroup.ID)
+			syncedResource, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.ConsumerGroup,
+				tt.args.consumerGroup.ID,
+			)
 			assert.NoError(t, err)
 			assert.Equal(t, syncedResource.ID, tt.args.consumerGroup.ID)
 
@@ -677,7 +713,11 @@ func TestPublishSSLs(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.SSL], 1)
 
 			// assert sync resource
-			syncedResource, err := GetSyncedItemByID(tt.args.ctx, tt.args.ssl.ID)
+			syncedResource, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.SSL,
+				tt.args.ssl.ID,
+			)
 			assert.NoError(t, err)
 			assert.Equal(t, syncedResource.ID, tt.args.ssl.ID)
 
@@ -739,7 +779,11 @@ func TestPublishStreamRoutes(t *testing.T) {
 			assert.Equal(t, syncedResourceTypeStats[constant.StreamRoute], 1)
 
 			// assert sync resource
-			syncedStreamRoute, err := GetSyncedItemByID(tt.args.ctx, tt.args.streamRoute.ID)
+			syncedStreamRoute, err := GetSyncedItemByResourceTypeAndID(
+				tt.args.ctx,
+				constant.StreamRoute,
+				tt.args.streamRoute.ID,
+			)
 			assert.NoError(t, err)
 
 			assert.Equal(t, syncedStreamRoute.ID, tt.args.streamRoute.ID)

--- a/src/apiserver/pkg/biz/sync_item.go
+++ b/src/apiserver/pkg/biz/sync_item.go
@@ -23,6 +23,7 @@ import (
 
 	"gorm.io/gen/field"
 
+	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/constant"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/entity/model"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/infras/logging"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/repo"
@@ -104,8 +105,12 @@ func QuerySyncedItems(ctx context.Context, param map[string]any) ([]*model.Gatew
 	return buildSyncedItemQuery(ctx).Where(field.Attrs(param)).Find()
 }
 
-// GetSyncedItemByID 通过 ID 获取同步资源
-func GetSyncedItemByID(ctx context.Context, id string) (*model.GatewaySyncData, error) {
+// GetSyncedItemByResourceTypeAndID 通过 ResourceType 和 ID 获取同步资源
+func GetSyncedItemByResourceTypeAndID(
+	ctx context.Context,
+	resourceType constant.APISIXResource,
+	id string,
+) (*model.GatewaySyncData, error) {
 	u := repo.GatewaySyncData
-	return buildSyncedItemQuery(ctx).Where(u.ID.Eq(id)).Take()
+	return buildSyncedItemQuery(ctx).Where(u.Type.Eq(string(resourceType)), u.ID.Eq(id)).Take()
 }

--- a/src/apiserver/pkg/biz/unify_op.go
+++ b/src/apiserver/pkg/biz/unify_op.go
@@ -1280,7 +1280,7 @@ func GetResourceConfigDiffDetail(
 ) (*dto.ResourceDiffDetailResponse, error) {
 	// 获取同步资源配置
 	syncedResourceConfig := json.RawMessage("{}")
-	syncedResource, err := GetSyncedItemByID(ctx, id)
+	syncedResource, err := GetSyncedItemByResourceTypeAndID(ctx, resourceType, id)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}


### PR DESCRIPTION
Why this change was needed:
The gateway_sync_data table stores different resource types (route, service, upstream, consumer, etc.) and different resources can have the same ID across types. Querying only by ID without filtering by resource type could return incorrect results when multiple resources share the same ID value.

What changed:
- Renamed GetSyncedItemByID to GetSyncedItemByResourceTypeAndID
- Added resourceType parameter to sync item queries
- Updated WHERE clause to filter by both type and ID
- Updated all 11 test cases across all APISIX resource types
- Updated GetResourceConfigDiffDetail to pass resource type

Problem solved:
Sync item lookups now correctly identify resources by both type and ID, preventing incorrect results in diff comparisons and resource retrieval operations when IDs collide across different resource types.

Files modified:
- pkg/biz/sync_item.go (function signature and query)
- pkg/biz/unify_op.go (diff detail function)
- pkg/biz/publish_test.go (11 test cases updated)

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)