### PR TITLE
refactor(biz): tighten review cleanup seams

### DIFF
--- a/src/apiserver/AGENTS.md
+++ b/src/apiserver/AGENTS.md
@@ -151,13 +151,13 @@ flowchart TD
 
 | Step | Function | File | Description |
 |------|----------|------|-------------|
-| 1. Sync | `SyncWithPrefix()` | `pkg/biz/unify_op.go` | Fetches resources from etcd, stores in `gateway_sync_data` |
-| 1. Sync | `SyncerRun()` | `pkg/biz/unify_op.go` | Periodic scheduler that runs sync for all gateways |
-| 2. Import | `AddSyncedResources()` | `pkg/biz/unify_op.go` | Copies synced resources to edit area tables |
+| 1. Sync | `SyncWithPrefix()` | `pkg/biz/unifyop/sync.go` | Fetches resources from etcd, stores in `gateway_sync_data` |
+| 1. Sync | `SyncerRun()` | `pkg/biz/unifyop/sync.go` | Periodic scheduler that runs sync for all gateways |
+| 2. Import | `AddSyncedResources()` | `pkg/biz/unifyop/sync.go` | Copies synced resources to edit area tables |
 | 3. CRUD | Various handlers | `pkg/apis/web/handler/*.go` | User creates/updates/deletes resources |
-| 4. Diff | `DiffResources()` | `pkg/biz/unify_op.go` | Compares edit area with sync area |
-| 5. Publish | `PublishResource()` | `pkg/biz/publish.go` | Writes changes to etcd |
-| 5. Publish | `putXxx()` functions | `pkg/biz/publish.go` | Resource-specific publish logic |
+| 4. Diff | `DiffResources()` | `pkg/biz/diff/diff.go` | Compares edit area with sync area |
+| 5. Publish | `PublishResource()` | `pkg/biz/publish/entry.go` | Writes changes to etcd |
+| 5. Publish | `putXxx()` functions | `pkg/biz/publish/entry.go` | Resource-specific publish logic |
 
 #### 1.2 Two-Area Design Rationale
 
@@ -330,7 +330,7 @@ func (r *Route) HandleConfig() error {
 
 #### 4.2 Publish Field Cleanup
 
-Before publishing to APISIX/etcd, `pkg/biz/publish.go` removes fields based on version compatibility using `ShouldRemoveFieldBeforeValidationOrPublish()`.
+Before publishing to APISIX/etcd, `pkg/biz/publish/payload.go` removes fields based on version compatibility using `ShouldRemoveFieldBeforeValidationOrPublish()`.
 
 ### 5. Schema Validation
 

--- a/src/apiserver/cmd/permission.go
+++ b/src/apiserver/cmd/permission.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/biz"
+	systembiz "github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/biz/system"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/config"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/constant"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/entity/dto"
@@ -65,13 +65,13 @@ func NewPermissionCmd() *cobra.Command {
 			repo.SetDefault(database.Client())
 			switch action {
 			case "add":
-				err = biz.AddAllowUsers(baseCtx, []string{user})
+				err = systembiz.AddAllowUsers(baseCtx, []string{user})
 				if err != nil {
 					log.Fatalf("add user %s failed: %s", user, err)
 					return
 				}
 			case "delete":
-				err = biz.RemoveUsers(baseCtx, []string{user})
+				err = systembiz.RemoveUsers(baseCtx, []string{user})
 				if err != nil {
 					log.Fatalf("delete user %s failed: %s", user, err)
 					return
@@ -80,7 +80,7 @@ func NewPermissionCmd() *cobra.Command {
 				log.Fatalf("action %s not support", action)
 			}
 			var users dto.UserWhiteList
-			err = biz.GetSystemConfigWithEntity(baseCtx, constant.SystemConfigUserWhitest, &users)
+			err = systembiz.GetSystemConfigWithEntity(baseCtx, constant.SystemConfigUserWhitest, &users)
 			if err != nil {
 				log.Fatalf("get user whitelist failed: %s", err)
 				return

--- a/src/apiserver/pkg/apis/open/handler/resource_test.go
+++ b/src/apiserver/pkg/apis/open/handler/resource_test.go
@@ -325,6 +325,42 @@ func TestResourceBatchCreateAcceptsEmptyBatchViaResolvedDraftContext(t *testing.
 	assert.Empty(t, createdResources)
 }
 
+func TestResourceBatchCreateRequiresResolvedDraftContext(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(
+		resourcebiz.BatchCheckNameDuplication,
+		func(ctx context.Context, resourceType constant.APISIXResource, names []string) (bool, error) {
+			assert.Equal(t, constant.Route, resourceType)
+			assert.Equal(t, []string{"route-demo"}, names)
+			return false, nil
+		},
+	)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/resources/routes/", func(c *gin.Context) {
+		ginx.SetGatewayInfo(c, &model.Gateway{ID: 42, APISIXVersion: "3.13.0"})
+		ginx.SetUserID(c, "openapi-user")
+		ginx.SetResourceType(c, constant.Route)
+		openhandler.ResourceBatchCreate(c)
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/resources/routes/",
+		strings.NewReader(`[{"name":"route-demo","config":{"uri":"/demo"}}]`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "resolved open drafts mismatch")
+}
+
 func TestResourceUpdateWritesOuterNameBackIntoConfig(t *testing.T) {
 	var updatedResource *model.ResourceCommonModel
 

--- a/src/apiserver/pkg/apis/web/handler/create_handlers_test.go
+++ b/src/apiserver/pkg/apis/web/handler/create_handlers_test.go
@@ -83,21 +83,6 @@ func uniqueWebCreateName(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 }
 
-func assertCreateDraftCommonFields(
-	t *testing.T,
-	resourceID string,
-	gatewayID int,
-	creator string,
-	status constant.ResourceStatus,
-) {
-	t.Helper()
-
-	assert.NotEmpty(t, resourceID)
-	assert.Equal(t, constant.ResourceStatusCreateDraft, status)
-	assert.Equal(t, creator, creator)
-	assert.Equal(t, gatewayID, gatewayID)
-}
-
 func TestPluginConfigCreateCurrentBehavior(t *testing.T) {
 	initWebCreateHandlerTestEnv()
 

--- a/src/apiserver/pkg/apis/web/handler/operation_audit_log.go
+++ b/src/apiserver/pkg/apis/web/handler/operation_audit_log.go
@@ -28,7 +28,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/apis/web/serializer"
-	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/biz"
+	auditlogbiz "github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/biz/auditlog"
 	resourcebiz "github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/biz/resource"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/constant"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/entity/model"
@@ -169,7 +169,7 @@ func getOperationAuditLogResults(
 	offset int,
 	limit int,
 ) ([]serializer.OperationAuditLogListResponse, int64, error) {
-	operationAuditLogs, total, err := biz.ListPagedOperationAuditLogs(
+	operationAuditLogs, total, err := auditlogbiz.ListPagedOperationAuditLogs(
 		ctx,
 		queryParam,
 		req.ResourceID,
@@ -221,7 +221,7 @@ func getOperationAuditLogResultsByName(
 	offset int,
 	limit int,
 ) ([]serializer.OperationAuditLogListResponse, int64, error) {
-	operationAuditLogs, err := biz.ListOperationAuditLogs(
+	operationAuditLogs, err := auditlogbiz.ListOperationAuditLogs(
 		ctx,
 		queryParam,
 		req.ResourceID,

--- a/src/apiserver/pkg/apis/web/handler/synced_item.go
+++ b/src/apiserver/pkg/apis/web/handler/synced_item.go
@@ -16,24 +16,6 @@
  * to the current version of the project delivered to anyone in the future.
  */
 
-/*
- * TencentBlueKing is pleased to support the open source community by making
- * 蓝鲸智云 - 微网关 (BlueKing - APIGateway) available.
- * Copyright (C) 2025 Tencent. All rights reserved.
- * Licensed under the MIT License (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- *     http://opensource.org/licenses/MIT
- *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * We undertake not to change the open source license (MIT license) applicable
- * to the current version of the project delivered to anyone in the future.
- */
-
 package handler
 
 import (

--- a/src/apiserver/pkg/apis/web/handler/web_create_helpers.go
+++ b/src/apiserver/pkg/apis/web/handler/web_create_helpers.go
@@ -40,7 +40,7 @@ func bindAndValidateWebCreateWithGeneratedID(
 	if err := c.ShouldBindJSON(req); err != nil {
 		return err
 	}
-	// A typed callback keeps the hot path simple and avoids reflective field mutation.
+	// Some APISIX versions require the generated resource ID to be present during schema validation.
 	setResourceID(idx.GenResourceID(resourceType))
 	return validation.ValidateStruct(c.Request.Context(), req)
 }

--- a/src/apiserver/pkg/biz/auditlog/auditlog.go
+++ b/src/apiserver/pkg/biz/auditlog/auditlog.go
@@ -1,3 +1,21 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 微网关 (BlueKing - Micro APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
 // Package auditlog contains shared helpers for writing operation audit rows.
 package auditlog
 

--- a/src/apiserver/pkg/biz/auditlog/operation_audit_log.go
+++ b/src/apiserver/pkg/biz/auditlog/operation_audit_log.go
@@ -16,7 +16,7 @@
  * to the current version of the project delivered to anyone in the future.
  */
 
-package biz
+package auditlog
 
 import (
 	"context"

--- a/src/apiserver/pkg/biz/doc.go
+++ b/src/apiserver/pkg/biz/doc.go
@@ -1,2 +1,20 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 微网关 (BlueKing - Micro APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
 // Package biz exposes root-level business helpers.
 package biz

--- a/src/apiserver/pkg/biz/publish/entry.go
+++ b/src/apiserver/pkg/biz/publish/entry.go
@@ -91,13 +91,24 @@ var publishResourceHandlerMap = map[constant.APISIXResource]publishResourceHandl
 	},
 }
 
+func init() {
+	if len(publishResourceHandlerMap) != len(constant.ResourceTypeList) {
+		panic("publish resource handler map does not match resource type list")
+	}
+	for _, resourceType := range constant.ResourceTypeList {
+		if _, ok := publishResourceHandlerMap[resourceType]; !ok {
+			panic(fmt.Sprintf("publish resource handler missing for %s", resourceType))
+		}
+	}
+}
+
 // PublishResource 资源发布
 func PublishResource(ctx context.Context, resourceType constant.APISIXResource, resourceIDs []string) error {
 	handlers, ok := publishResourceHandlerMap[resourceType]
 	if !ok {
 		return fmt.Errorf("unsupported resource type: %s", resourceType)
 	}
-	err := WrapPublishResource(ctx, resourceType, resourceIDs, handlers)
+	err := wrapPublishResource(ctx, resourceType, resourceIDs, handlers)
 	if err != nil {
 		return err
 	}
@@ -105,16 +116,15 @@ func PublishResource(ctx context.Context, resourceType constant.APISIXResource, 
 	goroutinex.GoroutineWithRecovery(ctx, func() {
 		// 1s 后同步资源
 		time.Sleep(time.Second * 1)
-		_, err = unifyopbiz.SyncResources(ginx.CloneCtx(ctx), resourceType)
-		if err != nil {
-			logging.Errorf("sync resources failed, err: %v", err)
+		if _, syncErr := unifyopbiz.SyncResources(ginx.CloneCtx(ctx), resourceType); syncErr != nil {
+			logging.Errorf("sync resources failed, err: %v", syncErr)
 		}
 	})
 	return nil
 }
 
-// WrapPublishResource PublishResource 资源发布进行一些公共操作
-func WrapPublishResource(ctx context.Context, resourceType constant.APISIXResource, resourceIDs []string,
+// wrapPublishResource runs the shared publish status transition, persistence, and audit workflow.
+func wrapPublishResource(ctx context.Context, resourceType constant.APISIXResource, resourceIDs []string,
 	handlers publishResourceHandlers,
 ) error {
 	// 状态机判断
@@ -220,8 +230,8 @@ func PublishAllResource(ctx context.Context, gatewayID int) error {
 	return nil
 }
 
-// FormatResourceIDNameList 格式化资源 ID 和名称列表
-func FormatResourceIDNameList(resources any, resourceType constant.APISIXResource) []string {
+// formatResourceIDNameList 格式化资源 ID 和名称列表
+func formatResourceIDNameList(resources any, resourceType constant.APISIXResource) []string {
 	switch resourceType {
 	case constant.Route:
 		routes := resources.([]*model.Route) //nolint:forcetypeassert
@@ -287,14 +297,6 @@ func getEtcdPublisher(ctx context.Context) (*publisher.EtcdPublisher, error) {
 	return pub, nil
 }
 
-func batchCreateEtcdResource(ctx context.Context, ops []publisher.ResourceOperation) error {
-	etcdPublisher, err := getEtcdPublisher(ctx)
-	if err != nil {
-		return err
-	}
-	return etcdPublisher.BatchCreate(ctx, ops)
-}
-
 func batchDeleteEtcdResource(ctx context.Context, resourceType constant.APISIXResource, ids []string) error {
 	pub, err := getEtcdPublisher(ctx)
 	if err != nil {
@@ -334,7 +336,7 @@ func deleteServices(ctx context.Context, serviceIDs []string) error {
 		return err
 	}
 	if len(routes) > 0 {
-		return fmt.Errorf("服务不可删除, 存在关联的路由资源 %v", FormatResourceIDNameList(routes, constant.Route))
+		return fmt.Errorf("服务不可删除, 存在关联的路由资源 %v", formatResourceIDNameList(routes, constant.Route))
 	}
 	// 判断 service 有没有关联的 streamRoute 数据
 	streamRoutes, err := resourcebiz.QueryStreamRoutes(ctx, map[string]any{"service_id": serviceIDs})
@@ -344,7 +346,7 @@ func deleteServices(ctx context.Context, serviceIDs []string) error {
 	if len(streamRoutes) > 0 {
 		return fmt.Errorf(
 			"服务不可删除, 存在关联的 streamRoute 资源 %v",
-			FormatResourceIDNameList(streamRoutes, constant.StreamRoute),
+			formatResourceIDNameList(streamRoutes, constant.StreamRoute),
 		)
 	}
 	// 先删除 etcd 的数据
@@ -364,7 +366,7 @@ func deleteUpstreams(ctx context.Context, upstreamIDs []string) error {
 		return err
 	}
 	if len(services) > 0 {
-		return fmt.Errorf("上游不可删除, 存在关联的服务资源 %v", FormatResourceIDNameList(services, constant.Service))
+		return fmt.Errorf("上游不可删除, 存在关联的服务资源 %v", formatResourceIDNameList(services, constant.Service))
 	}
 	// 判断 upstream 有没有关联的 route 数据
 	routes, err := resourcebiz.QueryRoutes(ctx, map[string]any{"upstream_id": upstreamIDs})
@@ -372,7 +374,7 @@ func deleteUpstreams(ctx context.Context, upstreamIDs []string) error {
 		return err
 	}
 	if len(routes) > 0 {
-		return fmt.Errorf("上游不可删除, 存在关联的路由资源 %v", FormatResourceIDNameList(routes, constant.Route))
+		return fmt.Errorf("上游不可删除, 存在关联的路由资源 %v", formatResourceIDNameList(routes, constant.Route))
 	}
 	// 判断 upstream 有没有关联的 streamRoute 数据
 	streamRoutes, err := resourcebiz.QueryStreamRoutes(ctx, map[string]any{"upstream_id": upstreamIDs})
@@ -382,7 +384,7 @@ func deleteUpstreams(ctx context.Context, upstreamIDs []string) error {
 	if len(streamRoutes) > 0 {
 		return fmt.Errorf(
 			"上游不可删除, 存在关联的 streamRoute 资源 %v",
-			FormatResourceIDNameList(streamRoutes, constant.StreamRoute),
+			formatResourceIDNameList(streamRoutes, constant.StreamRoute),
 		)
 	}
 
@@ -404,7 +406,7 @@ func deletePluginConfigs(ctx context.Context, pluginConfigIDs []string) error {
 		return err
 	}
 	if len(routes) > 0 {
-		return fmt.Errorf("插件组不可删除, 存在关联的路由资源 %v", FormatResourceIDNameList(routes, constant.Route))
+		return fmt.Errorf("插件组不可删除, 存在关联的路由资源 %v", formatResourceIDNameList(routes, constant.Route))
 	}
 
 	// 先删除 etcd 的数据
@@ -448,7 +450,7 @@ func deleteConsumerGroups(ctx context.Context, consumerGroupIDs []string) error 
 		return err
 	}
 	if len(consumers) > 0 {
-		return fmt.Errorf("消费者组不可删除, 存在关联的消费者资源 %v", FormatResourceIDNameList(consumers, constant.Consumer))
+		return fmt.Errorf("消费者组不可删除, 存在关联的消费者资源 %v", formatResourceIDNameList(consumers, constant.Consumer))
 	}
 	// 先删除 etcd 的数据
 	err = batchDeleteEtcdResource(ctx, constant.ConsumerGroup, consumerGroupIDs)
@@ -487,7 +489,7 @@ func deleteSSLs(ctx context.Context, sslIDs []string) error {
 		return err
 	}
 	if len(upstreams) > 0 {
-		return fmt.Errorf("ssl 不可删除, 存在关联的上游资源 %v", FormatResourceIDNameList(upstreams, constant.Upstream))
+		return fmt.Errorf("ssl 不可删除, 存在关联的上游资源 %v", formatResourceIDNameList(upstreams, constant.Upstream))
 	}
 	// 先删除 etcd 的数据
 	err = batchDeleteEtcdResource(ctx, constant.SSL, sslIDs)

--- a/src/apiserver/pkg/biz/publish/entry_test.go
+++ b/src/apiserver/pkg/biz/publish/entry_test.go
@@ -23,7 +23,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	gomonkey "github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -37,6 +39,7 @@ import (
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/constant"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/entity/base"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/entity/model"
+	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/repo"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/utils/cryptography"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/utils/ginx"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/tests/data"
@@ -143,6 +146,184 @@ func mustPublishResource(
 
 	if err := PublishResource(ctx, resourceType, []string{resourceID}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPublishResourceRejectsUnsupportedTypeAndMissingIDs(t *testing.T) {
+	_, ctx := newPublishGatewayContext(t, "3.11.0")
+
+	err := PublishResource(ctx, constant.Schema, []string{"schema-id"})
+	assert.ErrorContains(t, err, "unsupported resource type")
+
+	err = PublishResource(ctx, constant.Route, []string{"missing-route-id"})
+	assert.ErrorContains(t, err, "未找到指定的 路由 资源 IDs")
+}
+
+func TestPublishResourceTriggersBackgroundSync(t *testing.T) {
+	synced := make(chan constant.APISIXResource, 1)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(
+		wrapPublishResource,
+		func(context.Context, constant.APISIXResource, []string, publishResourceHandlers) error {
+			return nil
+		},
+	)
+	patches.ApplyFunc(
+		unifyopbiz.SyncResources,
+		func(ctx context.Context, resourceType constant.APISIXResource) (map[constant.APISIXResource]int, error) {
+			synced <- resourceType
+			return map[constant.APISIXResource]int{resourceType: 1}, nil
+		},
+	)
+
+	err := PublishResource(context.Background(), constant.Route, []string{"route-id"})
+	assert.NoError(t, err)
+
+	select {
+	case resourceType := <-synced:
+		assert.Equal(t, constant.Route, resourceType)
+	case <-time.After(2 * time.Second):
+		t.Fatal("background sync was not triggered")
+	}
+}
+
+func TestPublishResourceWritesAuditLog(t *testing.T) {
+	gateway, ctx := newPublishGatewayContext(t, "3.11.0")
+	ctx = context.WithValue(ctx, constant.UserIDKey, "publish-audit-tester")
+
+	route := data.Route1WithNoRelationResource(gateway, constant.ResourceStatusCreateDraft)
+	if err := resourcebiz.CreateRoute(ctx, *route); err != nil {
+		t.Fatal(err)
+	}
+
+	mustPublishResource(t, ctx, constant.Route, route.ID)
+
+	u := repo.OperationAuditLog
+	logs, err := u.WithContext(ctx).
+		Where(
+			u.GatewayID.Eq(gateway.ID),
+			u.ResourceType.Eq(string(constant.Route)),
+			u.OperationType.Eq(string(constant.OperationTypePublish)),
+		).
+		Find()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !assert.Len(t, logs, 1) {
+		return
+	}
+	assert.Equal(t, constant.OperationTypePublish, logs[0].OperationType)
+	assert.Equal(t, route.ID, logs[0].ResourceIDs)
+	assert.Equal(t, "publish-audit-tester", logs[0].Operator)
+}
+
+func TestPublishResourceDeleteIntegrityGuards(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, gateway *model.Gateway, ctx context.Context) (constant.APISIXResource, string)
+		wantErrText string
+	}{
+		{
+			name: "service with route",
+			setup: func(t *testing.T, gateway *model.Gateway, ctx context.Context) (constant.APISIXResource, string) {
+				t.Helper()
+				service := data.Service1WithNoRelation(gateway, constant.ResourceStatusDeleteDraft)
+				if err := resourcebiz.CreateService(ctx, *service); err != nil {
+					t.Fatal(err)
+				}
+				route := data.Route1WithNoRelationResource(gateway, constant.ResourceStatusSuccess)
+				route.ServiceID = service.ID
+				if err := resourcebiz.CreateRoute(ctx, *route); err != nil {
+					t.Fatal(err)
+				}
+				return constant.Service, service.ID
+			},
+			wantErrText: "服务不可删除",
+		},
+		{
+			name: "upstream with service",
+			setup: func(t *testing.T, gateway *model.Gateway, ctx context.Context) (constant.APISIXResource, string) {
+				t.Helper()
+				upstream := data.Upstream1WithNoRelation(gateway, constant.ResourceStatusDeleteDraft)
+				if err := resourcebiz.CreateUpstream(ctx, *upstream); err != nil {
+					t.Fatal(err)
+				}
+				service := data.Service1WithNoRelation(gateway, constant.ResourceStatusSuccess)
+				service.UpstreamID = upstream.ID
+				if err := resourcebiz.CreateService(ctx, *service); err != nil {
+					t.Fatal(err)
+				}
+				return constant.Upstream, upstream.ID
+			},
+			wantErrText: "上游不可删除",
+		},
+		{
+			name: "plugin config with route",
+			setup: func(t *testing.T, gateway *model.Gateway, ctx context.Context) (constant.APISIXResource, string) {
+				t.Helper()
+				pluginConfig := data.PluginConfig1WithNoRelation(
+					gateway,
+					constant.ResourceStatusDeleteDraft,
+				)
+				if err := resourcebiz.CreatePluginConfig(ctx, *pluginConfig); err != nil {
+					t.Fatal(err)
+				}
+				route := data.Route1WithNoRelationResource(gateway, constant.ResourceStatusSuccess)
+				route.PluginConfigID = pluginConfig.ID
+				if err := resourcebiz.CreateRoute(ctx, *route); err != nil {
+					t.Fatal(err)
+				}
+				return constant.PluginConfig, pluginConfig.ID
+			},
+			wantErrText: "插件组不可删除",
+		},
+		{
+			name: "consumer group with consumer",
+			setup: func(t *testing.T, gateway *model.Gateway, ctx context.Context) (constant.APISIXResource, string) {
+				t.Helper()
+				group := data.ConsumerGroup1WithNoRelation(gateway, constant.ResourceStatusDeleteDraft)
+				if err := resourcebiz.CreateConsumerGroup(ctx, *group); err != nil {
+					t.Fatal(err)
+				}
+				consumer := data.Consumer1WithNoRelation(gateway, constant.ResourceStatusSuccess)
+				consumer.GroupID = group.ID
+				if err := resourcebiz.CreateConsumer(ctx, *consumer); err != nil {
+					t.Fatal(err)
+				}
+				return constant.ConsumerGroup, group.ID
+			},
+			wantErrText: "消费者组不可删除",
+		},
+		{
+			name: "ssl with upstream",
+			setup: func(t *testing.T, gateway *model.Gateway, ctx context.Context) (constant.APISIXResource, string) {
+				t.Helper()
+				ssl := data.SSL1(gateway, constant.ResourceStatusDeleteDraft)
+				if err := resourcebiz.CreateSSL(ctx, ssl); err != nil {
+					t.Fatal(err)
+				}
+				upstream := data.Upstream1WithNoRelation(gateway, constant.ResourceStatusSuccess)
+				upstream.SSLID = ssl.ID
+				if err := resourcebiz.CreateUpstream(ctx, *upstream); err != nil {
+					t.Fatal(err)
+				}
+				return constant.SSL, ssl.ID
+			},
+			wantErrText: "ssl 不可删除",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gateway, ctx := newPublishGatewayContext(t, "3.11.0")
+			resourceType, resourceID := tt.setup(t, gateway, ctx)
+
+			err := PublishResource(ctx, resourceType, []string{resourceID})
+			assert.ErrorContains(t, err, tt.wantErrText)
+		})
 	}
 }
 
@@ -363,6 +544,32 @@ func TestPublishDependencyFanout_CurrentSeams(t *testing.T) {
 
 		assert.Equal(t, service.ID, mustSyncAndGetSyncedItem(t, ctx, constant.Service, service.ID).ID)
 		assert.Equal(t, upstream.ID, mustSyncAndGetSyncedItem(t, ctx, constant.Upstream, upstream.ID).ID)
+	})
+
+	t.Run("route republishes already-success upstream dependency", func(t *testing.T) {
+		gateway, ctx := newPublishGatewayContext(t, "3.11.0")
+
+		upstream := data.Upstream1WithNoRelation(gateway, constant.ResourceStatusSuccess)
+		if err := resourcebiz.CreateUpstream(ctx, *upstream); err != nil {
+			t.Fatal(err)
+		}
+
+		route := data.Route1WithNoRelationResource(gateway, constant.ResourceStatusCreateDraft)
+		route.UpstreamID = upstream.ID
+		route.Config = datatypes.JSON(`{"uris":["/already-success-dep"],"methods":["GET"]}`)
+		if err := resourcebiz.CreateRoute(ctx, *route); err != nil {
+			t.Fatal(err)
+		}
+
+		mustPublishResource(t, ctx, constant.Route, route.ID)
+
+		assert.Equal(t, route.ID, mustSyncAndGetSyncedItem(t, ctx, constant.Route, route.ID).ID)
+		assert.Equal(t, upstream.ID, mustSyncAndGetSyncedItem(t, ctx, constant.Upstream, upstream.ID).ID)
+		storedUpstream, err := resourcebiz.GetUpstream(ctx, upstream.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, constant.ResourceStatusSuccess, storedUpstream.Status)
 	})
 
 	t.Run("upstream publishes ssl dependency", func(t *testing.T) {

--- a/src/apiserver/pkg/biz/publish/payload_test.go
+++ b/src/apiserver/pkg/biz/publish/payload_test.go
@@ -195,6 +195,21 @@ func TestBuildPublishResourceOperation(t *testing.T) {
 			wantKey:    "pc-id",
 			wantConfig: `{"id":"pc-id","name":"pc-demo","create_time":1700000000,"update_time":1700000001,"plugins":{}}`,
 		},
+		{
+			name: "consumer removes nil base id before publish",
+			input: publishResourceOperationInput{
+				ResourceType: constant.Consumer,
+				ResourceKey:  "consumer-id",
+				BaseInfo: entity.BaseInfo{
+					CreateTime: 1700000000,
+					UpdateTime: 1700000001,
+				},
+				Version:   constant.APISIXVersion311,
+				RawConfig: json.RawMessage(`{"username":"consumer-demo","plugins":{}}`),
+			},
+			wantKey:    "consumer-id",
+			wantConfig: `{"username":"consumer-demo","create_time":1700000000,"update_time":1700000001,"plugins":{}}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -206,4 +221,19 @@ func TestBuildPublishResourceOperation(t *testing.T) {
 			assert.JSONEq(t, tt.wantConfig, string(got.Config))
 		})
 	}
+}
+
+func TestBuildPublishResourceOperationReturnsErrorForInvalidRawConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildPublishResourceOperation(publishResourceOperationInput{
+		ResourceType: constant.Route,
+		ResourceKey:  "route-id",
+		BaseInfo: entity.BaseInfo{
+			ID: "route-id",
+		},
+		Version:   constant.APISIXVersion311,
+		RawConfig: json.RawMessage(`{"uri":`),
+	})
+	assert.Error(t, err)
 }

--- a/src/apiserver/pkg/biz/publish/persist.go
+++ b/src/apiserver/pkg/biz/publish/persist.go
@@ -30,6 +30,14 @@ import (
 
 var batchUpdateResourceStatus = resourcebiz.BatchUpdateResourceStatus
 
+func batchCreateEtcdResource(ctx context.Context, ops []publisher.ResourceOperation) error {
+	etcdPublisher, err := getEtcdPublisher(ctx)
+	if err != nil {
+		return err
+	}
+	return etcdPublisher.BatchCreate(ctx, ops)
+}
+
 func persistPublishedOperations(
 	ctx context.Context,
 	resourceType constant.APISIXResource,

--- a/src/apiserver/pkg/biz/publish/persist_test.go
+++ b/src/apiserver/pkg/biz/publish/persist_test.go
@@ -21,6 +21,7 @@ package publish
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	gomonkey "github.com/agiledragon/gomonkey/v2"
@@ -31,8 +32,6 @@ import (
 )
 
 func TestPersistPublishedOperations(t *testing.T) {
-	t.Parallel()
-
 	var (
 		calledCreate bool
 		calledStatus bool
@@ -76,4 +75,64 @@ func TestPersistPublishedOperations(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, calledCreate)
 	assert.True(t, calledStatus)
+}
+
+func TestPersistPublishedOperationsReturnsCreateError(t *testing.T) {
+	expectedErr := errors.New("create failed")
+	var calledStatus bool
+
+	patches := gomonkey.ApplyFunc(
+		batchCreateEtcdResource,
+		func(context.Context, []publisher.ResourceOperation) error {
+			return expectedErr
+		},
+	)
+	defer patches.Reset()
+
+	patches.ApplyFunc(
+		batchUpdateResourceStatus,
+		func(context.Context, constant.APISIXResource, []string, constant.ResourceStatus) error {
+			calledStatus = true
+			return nil
+		},
+	)
+
+	err := persistPublishedOperations(
+		context.Background(),
+		constant.PluginConfig,
+		[]string{"pc-id"},
+		[]publisher.ResourceOperation{{Type: constant.PluginConfig, Key: "pc-id"}},
+		"插件组发布错误",
+	)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.False(t, calledStatus)
+}
+
+func TestPersistPublishedOperationsReturnsStatusError(t *testing.T) {
+	expectedErr := errors.New("status failed")
+
+	patches := gomonkey.ApplyFunc(
+		batchCreateEtcdResource,
+		func(context.Context, []publisher.ResourceOperation) error {
+			return nil
+		},
+	)
+	defer patches.Reset()
+
+	patches.ApplyFunc(
+		batchUpdateResourceStatus,
+		func(context.Context, constant.APISIXResource, []string, constant.ResourceStatus) error {
+			return expectedErr
+		},
+	)
+
+	err := persistPublishedOperations(
+		context.Background(),
+		constant.PluginConfig,
+		[]string{"pc-id"},
+		[]publisher.ResourceOperation{{Type: constant.PluginConfig, Key: "pc-id"}},
+		"插件组发布错误",
+	)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Contains(t, err.Error(), "插件组发布错误")
 }

--- a/src/apiserver/pkg/biz/schema/schema.go
+++ b/src/apiserver/pkg/biz/schema/schema.go
@@ -1,3 +1,21 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 微网关 (BlueKing - Micro APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
 // Package schema contains gateway custom plugin schema CRUD and lookup helpers.
 package schema
 

--- a/src/apiserver/pkg/biz/system/config.go
+++ b/src/apiserver/pkg/biz/system/config.go
@@ -16,7 +16,8 @@
  * to the current version of the project delivered to anyone in the future.
  */
 
-package biz
+// Package system provides system-level business configuration helpers.
+package system
 
 import (
 	"context"

--- a/src/apiserver/pkg/biz/unifyop/sync.go
+++ b/src/apiserver/pkg/biz/unifyop/sync.go
@@ -476,15 +476,8 @@ func (s *UnifyOp) SyncerRun(ctx context.Context) {
 	s.elector.Run(ctx)
 	s.elector.WaitForLeading()
 	s.isLeader = s.elector.IsLeader()
-	// 随机数种子
-	rand.NewSource(time.Now().UnixNano())
-	minDelay := 1
-	maxDelay := 300
-	ticker := time.NewTicker(config.G.Biz.SyncInterval +
-		time.Second*time.Duration(
-			rand.Intn(maxDelay-minDelay+1)+minDelay, //nolint:gosec // G404: non-security random for jitter
-		))
-	for range ticker.C {
+	for {
+		time.Sleep(nextSyncInterval(config.G.Biz.SyncInterval))
 		// prefix 可能会更新，再查一次
 		gatewayInfo, err := gatewaybiz.GetGateway(ctx, s.gatewayInfo.ID)
 		if err != nil {
@@ -500,6 +493,13 @@ func (s *UnifyOp) SyncerRun(ctx context.Context) {
 			logging.Errorf("sync all error: %s", err.Error())
 		}
 	}
+}
+
+func nextSyncInterval(baseInterval time.Duration) time.Duration {
+	minDelay := 1
+	maxDelay := 300
+	jitter := rand.Intn(maxDelay-minDelay+1) + minDelay //nolint:gosec // G404: non-security random for jitter
+	return baseInterval + time.Second*time.Duration(jitter)
 }
 
 // SyncWithPrefix 同步 prefix 下面的所有资源

--- a/src/apiserver/pkg/biz/unifyop/sync_helpers_test.go
+++ b/src/apiserver/pkg/biz/unifyop/sync_helpers_test.go
@@ -204,7 +204,7 @@ func TestReconcilePluginMetadataSyncIDs(t *testing.T) {
 	assert.Equal(t, "new-plugin", resources[1].GetName())
 }
 
-func TestReconcilePluginMetadataSyncIDs_AlreadyDBID(t *testing.T) {
+func TestReconcilePluginMetadataSyncIDs_ExistingEtcdName(t *testing.T) {
 	ctx := ginx.SetGatewayInfoToContext(context.Background(), gatewayInfo)
 	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 

--- a/src/apiserver/pkg/middleware/openapi_resource_check.go
+++ b/src/apiserver/pkg/middleware/openapi_resource_check.go
@@ -43,9 +43,9 @@ import (
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/utils/validation"
 )
 
-var noneValidateSchemaHandlerMap = map[string]bool{
+var noneValidateSchemaHandlerSet = map[string]struct{}{
 	// 发布接口不需要进行 schema 校验
-	"handler.ResourcePublish": false,
+	"handler.ResourcePublish": {},
 }
 
 func prepareOpenValidationPayload(
@@ -138,7 +138,7 @@ func OpenAPIResourceCheck() gin.HandlerFunc {
 		fullHandlerName := c.HandlerName()
 		lastSlashIndex := strings.LastIndex(fullHandlerName, "/")
 		handlerName := fullHandlerName[lastSlashIndex+1:]
-		if _, ok := noneValidateSchemaHandlerMap[handlerName]; ok {
+		if _, ok := noneValidateSchemaHandlerSet[handlerName]; ok {
 			c.Next()
 			return
 		}

--- a/src/apiserver/pkg/middleware/permission.go
+++ b/src/apiserver/pkg/middleware/permission.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 
-	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/biz"
+	systembiz "github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/biz/system"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/config"
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/utils/ginx"
 )
@@ -37,7 +37,7 @@ func Permission() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		user := ginx.GetUserID(c)
 		if user != "" && config.G.Service.Standalone {
-			users, err := biz.GetAllowUsers(c.Request.Context())
+			users, err := systembiz.GetAllowUsers(c.Request.Context())
 			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 				ginx.SystemErrorJSONResponse(c, err)
 				c.Abort()

--- a/src/apiserver/pkg/publisher/etcd_test.go
+++ b/src/apiserver/pkg/publisher/etcd_test.go
@@ -42,8 +42,6 @@ const (
 	batchCreateError = "batch create error"
 )
 
-var ctx context.Context
-
 type stubValidator struct {
 	validate func(obj json.RawMessage) error
 }


### PR DESCRIPTION
Why this change was needed:
Review follow-up found several small cleanup issues in the refactor branch: root biz leftovers, exported publish-only helpers, an unused handler-map bool, a captured background-sync error, one-shot sync jitter, and license/comment drift.

What changed:
- Move audit log queries into biz/auditlog and system config helpers into biz/system.
- Keep publish helper ownership local by unexporting package-private helpers and moving batchCreateEtcdResource beside persistPublishedOperations.
- Add publish handler-map completeness checks and use a local syncErr inside the background sync goroutine.
- Recompute sync jitter each loop and remove the discarded rand.NewSource call.
- Replace the non-validating OpenAPI handler map with a set and clean up license/comment drift.

Problem solved:
The refactor boundaries are now clearer, small latent maintenance hazards are removed, and the code better matches the package ownership introduced by the branch.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)