### PR TITLE
fix(idx): avoid case-folded resource ID collisions

### DIFF
--- a/src/apiserver/pkg/utils/idx/idx.go
+++ b/src/apiserver/pkg/utils/idx/idx.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/sony/sonyflake"
 
@@ -95,27 +94,6 @@ func getLocalIPs() ([]net.IP, error) {
 	return ips, nil
 }
 
-const base64Charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._"
-
-// uint64ToBase64
-func uint64ToBase64(num uint64) string {
-	if num == 0 {
-		return string(base64Charset[0])
-	}
-	var sb strings.Builder
-	for num > 0 {
-		remainder := num % 64
-		sb.WriteByte(base64Charset[remainder])
-		num /= 64
-	}
-	result := sb.String()
-	runes := []rune(result)
-	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
-		runes[i], runes[j] = runes[j], runes[i]
-	}
-	return string(runes)
-}
-
 // GenResourceID ...
 func GenResourceID(resourceType constant.APISIXResource) string {
 	uid, err := _sf.NextID()
@@ -123,5 +101,5 @@ func GenResourceID(resourceType constant.APISIXResource) string {
 		panic("get sony flake uid failed:" + err.Error())
 	}
 	prefix := resourceIDResourceTypePrefixMap[resourceType]
-	return fmt.Sprintf("bk.%s.%s", prefix, uint64ToBase64(uid))
+	return fmt.Sprintf("bk.%s.%s", prefix, strconv.FormatUint(uid, 36))
 }

--- a/src/apiserver/pkg/utils/idx/idx_test.go
+++ b/src/apiserver/pkg/utils/idx/idx_test.go
@@ -19,6 +19,7 @@
 package idx
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,22 @@ import (
 	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/constant"
 )
 
-func TestGetFlakeUid(t *testing.T) {
-	assert.True(t, len(GenResourceID(constant.Route)) < 64)
+func TestGenResourceID(t *testing.T) {
+	id := GenResourceID(constant.Route)
+	assert.True(t, len(id) < 64)
+	assert.Regexp(t, `^bk\.r\.[0-9a-z]+$`, id)
+	assert.Equal(t, strings.ToLower(id), id)
+}
+
+func TestGenResourceIDCaseFoldedUnique(t *testing.T) {
+	seen := make(map[string]string)
+	for i := 0; i < 1000; i++ {
+		id := GenResourceID(constant.Route)
+		folded := strings.ToLower(id)
+		previous, ok := seen[folded]
+		if !assert.Falsef(t, ok, "case-folded duplicate resource ID: previous=%s current=%s", previous, id) {
+			return
+		}
+		seen[folded] = id
+	}
 }


### PR DESCRIPTION
## Summary

- encode generated resource ID suffixes with lowercase base36 instead of mixed-case base64-like text
- keep sonyflake as the uniqueness source while avoiding MySQL case-insensitive index collisions
- add regression coverage for lowercase ID shape and case-folded uniqueness

## Verification

- `cd src/apiserver && source .envrc && make test`
- `cd src/apiserver && source .envrc && make lint`