### PR TITLE
fix(unify-op): keep plugin validation and diff flows compatible

### DIFF
--- a/src/apiserver/pkg/apis/web/handler/unify_op.go
+++ b/src/apiserver/pkg/apis/web/handler/unify_op.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/gin-gonic/gin"
 
@@ -178,13 +179,20 @@ func ResourcesDiffAll(c *gin.Context) {
 //	@Success	200			{object}	serializer.ResourceDiffResponse
 //	@Router		/api/v1/web/gateways/{gateway_id}/unify_op/resources/{type}/diff/ [post]
 func ResourcesDiff(c *gin.Context) {
+	resourceType := constant.APISIXResource(c.Param("type"))
+	if !isSupportedDiffResourceType(resourceType) {
+		// 批量发布会统一调用 diff；暂未映射到 APISIX 资源的批量操作类型先返回空 diff，避免阻塞发布流程。
+		ginx.SuccessJSONResponse(c, serializer.ResourceDiffResponse{})
+		return
+	}
+
 	var req serializer.ResourceDiffRequest
 	if err := validation.BindAndValidate(c, &req); err != nil {
 		ginx.BadRequestErrorJSONResponse(c, err)
 		return
 	}
 	result, err := diffbiz.DiffResources(c.Request.Context(),
-		constant.APISIXResource(c.Param("type")),
+		resourceType,
 		req.ResourceIDList,
 		req.Name,
 		serializer.OperationTypeToResourceStatus(req.OperationType),
@@ -195,6 +203,10 @@ func ResourcesDiff(c *gin.Context) {
 		return
 	}
 	ginx.SuccessJSONResponse(c, result)
+}
+
+func isSupportedDiffResourceType(resourceType constant.APISIXResource) bool {
+	return slices.Contains(constant.ResourceTypeList, resourceType)
 }
 
 // ResourceConfigDiffDetail  资源配置详情对比 ...

--- a/src/apiserver/pkg/apis/web/handler/unify_op_test.go
+++ b/src/apiserver/pkg/apis/web/handler/unify_op_test.go
@@ -1,0 +1,45 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 微网关 (BlueKing - Micro APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourcesDiffReturnsEmptyDiffForUnsupportedTypeBeforeBindingBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "type", Value: "plugin_custom"}}
+	c.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"resource_id_list":[33,16]}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	ResourcesDiff(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"data":[]`)
+	assert.NotContains(t, w.Body.String(), "cannot unmarshal")
+}

--- a/src/apiserver/pkg/utils/schema/3.11/schema.json
+++ b/src/apiserver/pkg/utils/schema/3.11/schema.json
@@ -7720,7 +7720,7 @@
         "properties": {
           "package": {
             "type": "string",
-            "pattern": "\\A([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)\\z",
+            "pattern": "^([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)$",
             "maxLength": 256
           },
           "keepalive_pool": {
@@ -7730,7 +7730,7 @@
           },
           "namespace": {
             "type": "string",
-            "pattern": "\\A([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)\\z",
+            "pattern": "^([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)$",
             "maxLength": 256
           },
           "service_token": {
@@ -7747,7 +7747,7 @@
           },
           "action": {
             "type": "string",
-            "pattern": "\\A([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)\\z",
+            "pattern": "^([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)$",
             "maxLength": 256
           },
           "_meta": {

--- a/src/apiserver/pkg/utils/schema/3.13/schema.json
+++ b/src/apiserver/pkg/utils/schema/3.13/schema.json
@@ -6051,12 +6051,12 @@
         "type": "object",
         "properties": {
           "action": {
-            "pattern": "\\A([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)\\z",
+            "pattern": "^([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)$",
             "type": "string",
             "maxLength": 256
           },
           "package": {
-            "pattern": "\\A([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)\\z",
+            "pattern": "^([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)$",
             "type": "string",
             "maxLength": 256
           },
@@ -6120,7 +6120,7 @@
             "type": "integer"
           },
           "namespace": {
-            "pattern": "\\A([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)\\z",
+            "pattern": "^([\\w]|[\\w][\\w@ .-]*[\\w@.-]+)$",
             "type": "string",
             "maxLength": 256
           },

--- a/src/apiserver/pkg/utils/schema/plugin_test.go
+++ b/src/apiserver/pkg/utils/schema/plugin_test.go
@@ -171,6 +171,45 @@ func TestPluginExamplesMatchSchema(t *testing.T) {
 	}
 }
 
+func TestOpenWhiskNamePatternsUseEcmaCompatibleAnchors(t *testing.T) {
+	versions := []constant.APISIXVersion{
+		constant.APISIXVersion311,
+		constant.APISIXVersion313,
+	}
+	expectedPattern := `^([\w]|[\w][\w@ .-]*[\w@.-]+)$`
+
+	for _, version := range versions {
+		t.Run(string(version), func(t *testing.T) {
+			schemaValue := GetPluginSchema(version, "openwhisk", "")
+			schemaMap, ok := schemaValue.(map[string]any)
+			if !assert.True(t, ok) {
+				return
+			}
+
+			properties, ok := schemaMap["properties"].(map[string]any)
+			if !assert.True(t, ok) {
+				return
+			}
+
+			for _, field := range []string{"action", "package", "namespace"} {
+				fieldSchema, ok := properties[field].(map[string]any)
+				if !assert.True(t, ok, field) {
+					continue
+				}
+
+				pattern, ok := fieldSchema["pattern"].(string)
+				if !assert.True(t, ok, field) {
+					continue
+				}
+
+				assert.Equal(t, expectedPattern, pattern, field)
+				assert.NotContains(t, pattern, `\A`, field)
+				assert.NotContains(t, pattern, `\z`, field)
+			}
+		})
+	}
+}
+
 func TestPluginCanonicalScopeInventory(t *testing.T) {
 	versions := []constant.APISIXVersion{
 		constant.APISIXVersion311,

--- a/src/frontend/src/components/table-resource-list.vue
+++ b/src/frontend/src/components/table-resource-list.vue
@@ -245,7 +245,7 @@ const {
       cell: (h, { row }: TableRowData) => row.config?.desc || '--',
     },
   ],
-  selectionColumn = [],
+  selectionColumn,
   actionColumn = [],
   excludeColumns = [],
   extraSearchOptions = [],
@@ -309,7 +309,7 @@ const setIndeterminate = computed(() => {
 });
 
 // 这里采用自定义checkbox是为了后续功能扩展，用自带的无法自定义渲染函数(暂时支持跨页选择，不支持跨页全选)
-const selectionColumns = shallowRef(selectionColumn?.length ? selectionColumn : [{
+const selectionColumns = shallowRef(selectionColumn === undefined ? [{
   colKey: 'row-select',
   type: 'custom-checkbox',
   align: 'center',
@@ -363,7 +363,7 @@ const selectionColumns = shallowRef(selectionColumn?.length ? selectionColumn : 
       />
     );
   },
-}]);
+}] : selectionColumn);
 
 const searchParams = ref<ISearchParam[]>([]);
 


### PR DESCRIPTION
Why this change was needed:
OpenWhisk plugin configs failed in the console because schema patterns copied from APISIX used PCRE anchors that AJV cannot compile. Batch publish also calls the diff endpoint for each operation type, so unsupported temporary types could abort the publish flow.

What changed:
- Normalized OpenWhisk action/package/namespace schema patterns for APISIX 3.11 and 3.13 to ECMA-compatible anchors
- Added schema regression coverage for those patterns
- Returned an empty diff response for unsupported web diff resource types with a compatibility comment
- Added handler coverage for the unsupported diff type branch
- Allowed an explicit empty selectionColumn to disable the default table selection column

Problem solved:
The management console can validate OpenWhisk plugin forms, and batch publish can continue when diff is called for a type not yet mapped to APISIX resources.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)