### PR TITLE
fix(schema): align consumer plugin examples with schemas

### DIFF
--- a/src/apiserver/pkg/utils/schema/3.11/plugin.json
+++ b/src/apiserver/pkg/utils/schema/3.11/plugin.json
@@ -527,6 +527,10 @@
       "header": "Authorization",
       "forward_header": "X-Decrypted-Token",
       "strict": true
+    },
+    "consumer_example": {
+      "key": "user-key",
+      "secret": "my-secret-key"
     }
   },
   {

--- a/src/apiserver/pkg/utils/schema/3.13/plugin.json
+++ b/src/apiserver/pkg/utils/schema/3.13/plugin.json
@@ -636,6 +636,10 @@
       "header": "Authorization",
       "forward_header": "X-Decrypted-Token",
       "strict": true
+    },
+    "consumer_example": {
+      "key": "user-key",
+      "secret": "my-secret-key"
     }
   },
   {

--- a/src/apiserver/pkg/utils/schema/3.13/schema.json
+++ b/src/apiserver/pkg/utils/schema/3.13/schema.json
@@ -8409,13 +8409,13 @@
     "basic-auth": {
       "version": 0.1,
       "schema": {
-        "anonymous_consumer": {
-          "minLength": 1,
-          "type": "string"
-        },
         "$comment": "this is a mark for our injected plugin schema",
         "type": "object",
         "properties": {
+          "anonymous_consumer": {
+            "minLength": 1,
+            "type": "string"
+          },
           "_meta": {
             "properties": {
               "pre_function": {

--- a/src/apiserver/pkg/utils/schema/plugin_test.go
+++ b/src/apiserver/pkg/utils/schema/plugin_test.go
@@ -171,6 +171,84 @@ func TestPluginExamplesMatchSchema(t *testing.T) {
 	}
 }
 
+func TestConsumerPluginFrontendFallbackExamplesMatchConsumerSchema(t *testing.T) {
+	versions := []constant.APISIXVersion{
+		constant.APISIXVersion311,
+		constant.APISIXVersion313,
+	}
+
+	for _, version := range versions {
+		plugins, err := GetPlugins(constant.APISIXTypeAPISIX, version)
+		if !assert.NoError(t, err) {
+			continue
+		}
+
+		for _, plugin := range plugins {
+			if !schemaVersionMap[version].Get("plugins." + plugin.Name + ".consumer_schema").Exists() {
+				continue
+			}
+
+			t.Run(fmt.Sprintf("%s/%s", version, plugin.Name), func(t *testing.T) {
+				example := plugin.ConsumerExample
+				if example == nil {
+					example = plugin.Example
+				}
+
+				schemaValue := GetPluginSchema(version, plugin.Name, "consumer")
+				if !assert.NotNil(t, schemaValue) {
+					return
+				}
+
+				schemaBytes, err := json.Marshal(schemaValue)
+				assert.NoError(t, err)
+
+				s, err := gojsonschema.NewSchema(gojsonschema.NewBytesLoader(schemaBytes))
+				assert.NoError(t, err)
+
+				result, err := s.Validate(gojsonschema.NewGoLoader(example))
+				assert.NoError(t, err)
+				assert.Truef(
+					t,
+					result.Valid(),
+					"schema validation errors: %s",
+					strings.Join(flattenSchemaErrors(result.Errors()), "; "),
+				)
+			})
+		}
+	}
+}
+
+func TestAnonymousConsumerIsDeclaredPropertyIn313PluginSchemas(t *testing.T) {
+	pluginNames := []string{
+		"hmac-auth",
+		"basic-auth",
+		"jwt-auth",
+		"key-auth",
+	}
+
+	for _, pluginName := range pluginNames {
+		t.Run(pluginName, func(t *testing.T) {
+			schemaValue := GetPluginSchema(constant.APISIXVersion313, pluginName, "")
+			if !assert.NotNil(t, schemaValue) {
+				return
+			}
+
+			schemaMap, ok := schemaValue.(map[string]any)
+			if !assert.True(t, ok) {
+				return
+			}
+
+			assert.NotContains(t, schemaMap, "anonymous_consumer")
+
+			properties, ok := schemaMap["properties"].(map[string]any)
+			if !assert.True(t, ok) {
+				return
+			}
+			assert.Contains(t, properties, "anonymous_consumer")
+		})
+	}
+}
+
 func TestOpenWhiskNamePatternsUseEcmaCompatibleAnchors(t *testing.T) {
 	versions := []constant.APISIXVersion{
 		constant.APISIXVersion311,


### PR DESCRIPTION
Why this change was needed:
Frontend consumer and consumer_group plugin editors validate against consumer schemas but use consumer_example when available, falling back to the normal plugin example otherwise. Plugins with consumer schemas need examples that match that consumer shape.

What changed:
- Added jwe-decrypt consumer examples for APISIX 3.11 and 3.13
- Moved 3.13 basic-auth anonymous_consumer under schema properties
- Added regression coverage for frontend fallback examples and anonymous_consumer placement

Problem solved:
Creating consumer or consumer_group plugins no longer fails schema validation because the default example has the wrong shape.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)