### PR TITLE
fix(web): fix IDOR vulnerability in etcd test connection API

### DIFF
--- a/src/apiserver/pkg/apis/web/handler/gateway.go
+++ b/src/apiserver/pkg/apis/web/handler/gateway.go
@@ -326,35 +326,34 @@ func GatewayCheckName(c *gin.Context) {
 //	@Success	200	{object}	serializer.EtcdTestConOutputInfo	"连通性测试结果信息"
 //	@Router		/api/v1/web/gateways/etcd/test_connection/ [post]
 func EtcdTestConnection(c *gin.Context) {
+	handleEtcdTestConnection(c, nil)
+}
+
+// GatewayEtcdTestConnection 编辑态 etcd 连通性测试（受 GatewayAccess 保护，gateway_id 从路径获取）
+//
+//	@ID			gateway_etcd_test_connection
+//	@Summary	网关 etcd 连通性测试
+//	@Param		gateway_id	path	int					true	"网关 ID"
+//	@Param		request		body	serializer.EtcdTestConnectionRequest	true	"etcd 配置连通性测试"
+//	@Tags		webapi.gateway
+//	@Success	200	{object}	serializer.EtcdTestConOutputInfo	"连通性测试结果信息"
+//	@Router		/api/v1/web/gateways/{gateway_id}/etcd/test_connection/ [post]
+func GatewayEtcdTestConnection(c *gin.Context) {
+	handleEtcdTestConnection(c, ginx.GetGatewayInfo(c))
+}
+
+func handleEtcdTestConnection(c *gin.Context, gateway *model.Gateway) {
 	var req serializer.EtcdTestConnectionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		ginx.BadRequestErrorJSONResponse(c, err)
 		return
 	}
-	if req.GatewayID != 0 {
-		gateway, err := gatewaybiz.GetGateway(c.Request.Context(), req.GatewayID)
-		if err != nil {
-			ginx.SystemErrorJSONResponse(c, err)
-			return
-		}
-		// 如果输入密码为脱敏信息，则替换为已保存的密码进行连通性测试
-		if req.EtcdSchemaType == constant.HTTP {
-			if req.EtcdPassword == constant.SensitiveInfoFiledDisplay {
-				req.EtcdPassword = gateway.EtcdConfig.Password
-			}
-		} else {
-			if req.EtcdCACert == gateway.EtcdConfig.GetMaskCaCert() {
-				req.EtcdCACert = gateway.EtcdConfig.CACert
-			}
-			if req.EtcdCertCert == gateway.EtcdConfig.GetMaskCertCert() {
-				req.EtcdCertCert = gateway.EtcdConfig.CertCert
-			}
-			if req.EtcdCertKey == gateway.EtcdConfig.GetMaskCertKey() {
-				req.EtcdCertKey = gateway.EtcdConfig.CertKey
-			}
-		}
+	fillEtcdTestConnectionSensitiveFields(&req, gateway)
+	gatewayID := 0
+	if gateway != nil {
+		gatewayID = gateway.ID
 	}
-	apisixVersion, _, err := common.CheckEtcdConnAndAPISIXInstance(req.GatewayID, req.EtcdConfig)
+	apisixVersion, _, err := common.CheckEtcdConnAndAPISIXInstance(gatewayID, req.EtcdConfig)
 	if err != nil {
 		ginx.BadRequestErrorJSONResponse(c, err)
 		return
@@ -363,4 +362,27 @@ func EtcdTestConnection(c *gin.Context) {
 		APISIXVersion: apisixVersion,
 	}
 	ginx.SuccessJSONResponse(c, output)
+}
+
+// fillEtcdTestConnectionSensitiveFields 将请求中的脱敏敏感字段替换为网关已保存的真实值。
+// 仅当 gateway 非 nil 时执行替换。
+func fillEtcdTestConnectionSensitiveFields(req *serializer.EtcdTestConnectionRequest, gateway *model.Gateway) {
+	if gateway == nil {
+		return
+	}
+	if req.EtcdSchemaType == constant.HTTP {
+		if req.EtcdPassword == constant.SensitiveInfoFiledDisplay {
+			req.EtcdPassword = gateway.EtcdConfig.Password
+		}
+		return
+	}
+	if req.EtcdCACert == gateway.EtcdConfig.GetMaskCaCert() {
+		req.EtcdCACert = gateway.EtcdConfig.CACert
+	}
+	if req.EtcdCertCert == gateway.EtcdConfig.GetMaskCertCert() {
+		req.EtcdCertCert = gateway.EtcdConfig.CertCert
+	}
+	if req.EtcdCertKey == gateway.EtcdConfig.GetMaskCertKey() {
+		req.EtcdCertKey = gateway.EtcdConfig.CertKey
+	}
 }

--- a/src/apiserver/pkg/apis/web/handler/gateway_test.go
+++ b/src/apiserver/pkg/apis/web/handler/gateway_test.go
@@ -1,0 +1,123 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 微网关 (BlueKing - Micro APIGateway) available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/apis/web/serializer"
+	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/constant"
+	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/entity/base"
+	"github.com/TencentBlueKing/blueking-micro-apigateway/apiserver/pkg/entity/model"
+)
+
+func TestFillEtcdTestConnectionSensitiveFieldsDoesNothingWithoutGateway(t *testing.T) {
+	req := serializer.EtcdTestConnectionRequest{}
+	req.EtcdPassword = "user-input"
+
+	fillEtcdTestConnectionSensitiveFields(&req, nil)
+
+	assert.Equal(t, "user-input", req.EtcdPassword)
+}
+
+func TestFillEtcdTestConnectionSensitiveFieldsReplacesMaskedHTTPPassword(t *testing.T) {
+	gateway := &model.Gateway{
+		ID: 12,
+		EtcdConfig: model.EtcdConfig{
+			EtcdConfig: base.EtcdConfig{
+				Password: "saved-password",
+			},
+		},
+	}
+	req := serializer.EtcdTestConnectionRequest{}
+	req.EtcdSchemaType = constant.HTTP
+	req.EtcdPassword = constant.SensitiveInfoFiledDisplay
+
+	fillEtcdTestConnectionSensitiveFields(&req, gateway)
+
+	assert.Equal(t, gateway.EtcdConfig.Password, req.EtcdPassword)
+}
+
+func TestFillEtcdTestConnectionSensitiveFieldsPreservesNonMaskedHTTPPassword(t *testing.T) {
+	gateway := &model.Gateway{
+		ID: 12,
+		EtcdConfig: model.EtcdConfig{
+			EtcdConfig: base.EtcdConfig{
+				Password: "saved-password",
+			},
+		},
+	}
+	req := serializer.EtcdTestConnectionRequest{}
+	req.EtcdSchemaType = constant.HTTP
+	req.EtcdPassword = "user-provided-password"
+
+	fillEtcdTestConnectionSensitiveFields(&req, gateway)
+
+	assert.Equal(t, "user-provided-password", req.EtcdPassword)
+}
+
+func TestFillEtcdTestConnectionSensitiveFieldsReplacesMaskedHTTPSCerts(t *testing.T) {
+	gateway := &model.Gateway{
+		ID: 34,
+		EtcdConfig: model.EtcdConfig{
+			EtcdConfig: base.EtcdConfig{
+				CACert:   "saved-ca",
+				CertCert: "saved-cert",
+				CertKey:  "saved-key",
+			},
+		},
+	}
+	req := serializer.EtcdTestConnectionRequest{}
+	req.EtcdSchemaType = constant.HTTPS
+	req.EtcdCACert = gateway.EtcdConfig.GetMaskCaCert()
+	req.EtcdCertCert = gateway.EtcdConfig.GetMaskCertCert()
+	req.EtcdCertKey = gateway.EtcdConfig.GetMaskCertKey()
+
+	fillEtcdTestConnectionSensitiveFields(&req, gateway)
+
+	assert.Equal(t, gateway.EtcdConfig.CACert, req.EtcdCACert)
+	assert.Equal(t, gateway.EtcdConfig.CertCert, req.EtcdCertCert)
+	assert.Equal(t, gateway.EtcdConfig.CertKey, req.EtcdCertKey)
+}
+
+func TestFillEtcdTestConnectionSensitiveFieldsPreservesNonMaskedHTTPSCerts(t *testing.T) {
+	gateway := &model.Gateway{
+		ID: 34,
+		EtcdConfig: model.EtcdConfig{
+			EtcdConfig: base.EtcdConfig{
+				CACert:   "saved-ca",
+				CertCert: "saved-cert",
+				CertKey:  "saved-key",
+			},
+		},
+	}
+	req := serializer.EtcdTestConnectionRequest{}
+	req.EtcdSchemaType = constant.HTTPS
+	req.EtcdCACert = "user-provided-ca"
+	req.EtcdCertCert = "user-provided-cert"
+	req.EtcdCertKey = "user-provided-key"
+
+	fillEtcdTestConnectionSensitiveFields(&req, gateway)
+
+	assert.Equal(t, "user-provided-ca", req.EtcdCACert)
+	assert.Equal(t, "user-provided-cert", req.EtcdCertCert)
+	assert.Equal(t, "user-provided-key", req.EtcdCertKey)
+}

--- a/src/apiserver/pkg/apis/web/router.go
+++ b/src/apiserver/pkg/apis/web/router.go
@@ -67,6 +67,7 @@ func RegisterWebApi(path string, router *gin.RouterGroup) {
 	gatewayGroup.Use(middleware.GatewayAccess())
 	gatewayGroup.Use(middleware.ResourceOperationCheck())
 
+	gatewayGroup.POST("/etcd/test_connection/", handler.GatewayEtcdTestConnection)
 	gatewayGroup.PUT("/", handler.GatewayUpdate)
 
 	gatewayGroup.GET("/", handler.GatewayGet)

--- a/src/apiserver/pkg/apis/web/serializer/gateway.go
+++ b/src/apiserver/pkg/apis/web/serializer/gateway.go
@@ -77,7 +77,6 @@ type CheckGatewayNameRequest struct {
 
 // EtcdTestConnectionRequest 探测etcd连接请求
 type EtcdTestConnectionRequest struct {
-	GatewayID int `json:"gateway_id"` // 编辑下探测需要传
 	common.EtcdConfig
 }
 


### PR DESCRIPTION
## Summary

Fixes an IDOR vulnerability where the edit-mode etcd test connection endpoint accepted an arbitrary gateway_id in the request body, allowing unauthorized etcd connectivity tests against other gateways.

## Changes

- **Security**: Move edit-mode endpoint under the gateway-scoped route protected by GatewayAccess middleware (`/gateways/:gateway_id/etcd/test_connection/`)
- **Security**: Remove `gateway_id` from `EtcdTestConnectionRequest` body; edit mode now trusts only the gateway injected by GatewayAccess
- **Compatibility**: Keep the public `/gateways/etcd/test_connection/` endpoint for create-mode testing
- **Refactor**: Extract `handleEtcdTestConnection` and `fillEtcdTestConnectionSensitiveFields` for shared logic
- **Tests**: Add unit tests covering nil gateway, masked/unmasked HTTP password, and masked/unmasked HTTPS certs

## Files Changed

- `pkg/apis/web/router.go`
- `pkg/apis/web/serializer/gateway.go`
- `pkg/apis/web/handler/gateway.go`
- `pkg/apis/web/handler/gateway_test.go`
