### PR TITLE
fix(apiserver): allow overriding Go module proxy

### DIFF
--- a/src/apiserver/Dockerfile
+++ b/src/apiserver/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /app
 
 ARG VERSION=latest
 ARG COMMIT=HEAD
+ARG GOPROXY=https://proxy.golang.org,direct
+
+ENV GOPROXY=${GOPROXY}
 
 # Copy go mod files first for better caching
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary
- add a configurable GOPROXY build argument to the apiserver builder image
- preserve the existing proxy.golang.org,direct behavior by default while allowing build jobs to select a reachable proxy

## Verification
- Docker builder image built successfully with GOPROXY=https://goproxy.cn,direct
- container go env GOPROXY returned the supplied override
- make lint: 0 issues
- make test: passed