### PR TITLE
fix(frontend): increase upstream timeout default

### DIFF
--- a/src/frontend/src/hooks/use-config-filter.ts
+++ b/src/frontend/src/hooks/use-config-filter.ts
@@ -76,9 +76,9 @@ export const defaultResourceConfigMap: Record<string, IDefaultConfigMap> = {
     },
     timeout: {
       default: {
-        send: 6,
-        connect: 6,
-        read: 6,
+        send: 60,
+        connect: 60,
+        read: 60,
       },
       advanced: true,
     },

--- a/src/frontend/src/views/upstream/use-upstream-form.ts
+++ b/src/frontend/src/views/upstream/use-upstream-form.ts
@@ -110,9 +110,9 @@ export const useUpstreamForm = () => {
     // discovery_type: 'dns',
     key: '',
     timeout: {
-      send: 6,
-      connect: 6,
-      read: 6,
+      send: 60,
+      connect: 60,
+      read: 60,
     },
     pass_host: 'pass',
     // upstream_host: '',


### PR DESCRIPTION
## Summary
- increase upstream connect, send, and read timeout defaults from 6s to 60s
- keep the upstream form defaults and advanced-config filtering defaults synchronized

## Verification
- `npm run lint`
- `npm run build` (passes with the existing webpack asset-size warnings)
- synchronized-default assertion: both timeout definitions resolve to `[60, 60, 60]`